### PR TITLE
fix: Fix gitops values yaml file link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM epamedp/headlamp:0.22.8
+FROM epamedp/headlamp:0.22.9
 
 COPY --chown=100:101 assets/ /headlamp/frontend
 COPY --chown=100:101 dist/main.js /headlamp/plugins/edp/main.js

--- a/src/pages/edp-stage-details/components/Applications/hooks/useColumns.tsx
+++ b/src/pages/edp-stage-details/components/Applications/hooks/useColumns.tsx
@@ -52,6 +52,7 @@ export const useColumns = (
   const { gitOpsCodebase } = useDataContext();
   const {
     stage: { data: stage, isLoading: isStageLoading },
+    gitServers: { data: gitServers, isLoading: isGitServersLoading },
   } = useDynamicDataContext();
   const _createArgoCDLink = React.useCallback(
     (argoApplication: ApplicationKubeObjectInterface) =>
@@ -63,6 +64,16 @@ export const useColumns = (
       ),
     [QuickLinksURLS]
   );
+
+  const gitOpsGitServer = React.useMemo(() => {
+    if (isGitServersLoading || gitOpsCodebase === null) {
+      return null;
+    }
+
+    return gitServers?.find(
+      (gitServer) => gitServer.metadata.name === gitOpsCodebase.data?.spec.gitServer
+    );
+  }, [gitOpsCodebase, gitServers, isGitServersLoading]);
 
   const isLoading = gitOpsCodebase === null || isStageLoading;
 
@@ -218,7 +229,7 @@ export const useColumns = (
                     CDPipelineName,
                     stage?.spec.name,
                     appName,
-                    gitOpsCodebase.data?.spec.gitServer as GIT_SERVERS
+                    gitOpsGitServer?.spec.gitProvider as GIT_SERVERS
                   )}
                   icon={ICONS.GIT_BRANCH}
                   name="source code"
@@ -386,7 +397,8 @@ export const useColumns = (
   }, [
     CDPipelineName,
     _createArgoCDLink,
-    gitOpsCodebase.data,
+    gitOpsCodebase.data?.status.gitWebUrl,
+    gitOpsGitServer?.spec.gitProvider,
     handleSelectRowClick,
     isLoading,
     selected,

--- a/src/pages/edp-stage-details/providers/DynamicData/context.ts
+++ b/src/pages/edp-stage-details/providers/DynamicData/context.ts
@@ -14,4 +14,5 @@ export const DynamicDataContext = React.createContext<DynamicDataContextProvider
   autotestRunnerPipelineRuns: initialData,
   argoApplications: initialData,
   deployPipelineRunTemplate: initialData,
+  gitServers: initialData,
 });

--- a/src/pages/edp-stage-details/providers/DynamicData/provider.tsx
+++ b/src/pages/edp-stage-details/providers/DynamicData/provider.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom';
 import { PIPELINE_TYPES } from '../../../../constants/pipelineTypes';
 import { useStreamApplicationListByPipelineStageLabel } from '../../../../k8s/Application/hooks/useStreamApplicationListByPipelineStageLabel';
 import { EDPCDPipelineStageKubeObject } from '../../../../k8s/EDPCDPipelineStage';
+import { EDPGitServerKubeObject } from '../../../../k8s/EDPGitServer';
 import { PipelineRunKubeObject } from '../../../../k8s/PipelineRun';
 import {
   PIPELINE_RUN_LABEL_SELECTOR_CDPIPELINE,
@@ -40,7 +41,8 @@ export const DynamicDataContextProvider: React.FC = ({ children }) => {
   const stageMetadataName = stage?.metadata.name;
   const stageTriggerTemplate = stage?.spec.triggerTemplate;
 
-  const [pipelineRuns] = PipelineRunKubeObject.useList();
+  const [pipelineRuns, pipelineRunsError] = PipelineRunKubeObject.useList();
+  const [gitServers, gitServersError] = EDPGitServerKubeObject.useList();
 
   const sortedPipelineRuns = React.useMemo(() => {
     if (pipelineRuns === null) {
@@ -117,17 +119,17 @@ export const DynamicDataContextProvider: React.FC = ({ children }) => {
       autotestPipelineRuns: {
         data: latestTenAutotestPipelineRuns,
         isLoading: latestTenAutotestPipelineRuns === null,
-        error: null,
+        error: pipelineRunsError,
       },
       deployPipelineRuns: {
         data: latestTenDeployPipelineRuns,
         isLoading: latestTenDeployPipelineRuns === null,
-        error: null,
+        error: pipelineRunsError,
       },
       autotestRunnerPipelineRuns: {
         data: latestTenAutotestRunnerPipelineRuns,
         isLoading: latestTenAutotestRunnerPipelineRuns === null,
-        error: null,
+        error: pipelineRunsError,
       },
       argoApplications: {
         data: argoApplications,
@@ -139,15 +141,25 @@ export const DynamicDataContextProvider: React.FC = ({ children }) => {
         isLoading: deployPipelineRunTemplate.isLoading,
         error: deployPipelineRunTemplate.error as ApiError,
       },
+      gitServers: {
+        data: gitServers,
+        isLoading: gitServers === null,
+        error: gitServersError,
+      },
     }),
     [
       stage,
       error,
       latestTenAutotestPipelineRuns,
+      pipelineRunsError,
       latestTenDeployPipelineRuns,
       latestTenAutotestRunnerPipelineRuns,
       argoApplications,
-      deployPipelineRunTemplate,
+      deployPipelineRunTemplate.data,
+      deployPipelineRunTemplate.isLoading,
+      deployPipelineRunTemplate.error,
+      gitServers,
+      gitServersError,
     ]
   );
 

--- a/src/pages/edp-stage-details/providers/DynamicData/types.ts
+++ b/src/pages/edp-stage-details/providers/DynamicData/types.ts
@@ -1,5 +1,6 @@
 import { ApplicationKubeObjectInterface } from '../../../../k8s/Application/types';
 import { EDPCDPipelineStageKubeObjectInterface } from '../../../../k8s/EDPCDPipelineStage/types';
+import { EDPGitServerKubeObjectInterface } from '../../../../k8s/EDPGitServer/types';
 import { PipelineRunKubeObjectInterface } from '../../../../k8s/PipelineRun/types';
 import { DataProviderValue } from '../../../../types/pages';
 
@@ -10,4 +11,5 @@ export interface DynamicDataContextProviderValue {
   autotestRunnerPipelineRuns: DataProviderValue<PipelineRunKubeObjectInterface[]>;
   argoApplications: DataProviderValue<ApplicationKubeObjectInterface[]>;
   deployPipelineRunTemplate: DataProviderValue<PipelineRunKubeObjectInterface>;
+  gitServers: DataProviderValue<EDPGitServerKubeObjectInterface[]>;
 }

--- a/src/widgets/ManageGitServer/index.tsx
+++ b/src/widgets/ManageGitServer/index.tsx
@@ -100,7 +100,7 @@ export const ManageGitServer = ({
               <CredentialsForm gitServerSecret={gitServerSecret} />
             </Grid>
             <Grid item xs={12}>
-              <Actions handleClosePanel={handleClosePanel} />
+              <Actions />
             </Grid>
           </Grid>
         </MultiFormContextProvider>


### PR DESCRIPTION
The "Go to the Source code" button on the stage page is currently not functional for GitServer values other than "gitlab", "github", or "gerrit". This issue arises from the application's inability to recognize and handle GitServer values outside these predefined ones. To address this issue, the application should dynamically search for the specific GitServer using the `gitOpsCodebase.spec.gitServer` field value and retrieve the `gitProvider` value from the identified GitServer. This solution will enable the "Go to the Source code" button to function correctly for any GitServer value.