### PR TITLE
feat: Exclude pipelinerun from resources displayed in argocd(#169)

### DIFF
--- a/src/k8s/PipelineRun/utils/createBuildPipelineRunInstance/index.test.ts
+++ b/src/k8s/PipelineRun/utils/createBuildPipelineRunInstance/index.test.ts
@@ -53,6 +53,9 @@ describe('testing createBuildPipelineRunInstance', () => {
           'app.edp.epam.com/codebase': 'test-codebase-name',
           'app.edp.epam.com/pipelinetype': 'build',
         },
+        annotations: {
+          'argocd.argoproj.io/compare-options': 'IgnoreExtraneous',
+        },
       },
       spec: {
         params: [

--- a/src/k8s/PipelineRun/utils/createBuildPipelineRunInstance/index.ts
+++ b/src/k8s/PipelineRun/utils/createBuildPipelineRunInstance/index.ts
@@ -59,6 +59,9 @@ export const createBuildPipelineRunInstance = ({
         'app.edp.epam.com/codebase': codebaseName,
         'app.edp.epam.com/pipelinetype': 'build',
       },
+      annotations: {
+        'argocd.argoproj.io/compare-options': 'IgnoreExtraneous',
+      },
     },
     spec: {
       params: [


### PR DESCRIPTION
Description
This patch adds a crucial annotation to the PipelineRun resource creation logic, aiming to exclude these resources from being displayed in the ArgoCD UI. The annotation 'argocd.argoproj.io/compare-options': 'IgnoreExtraneous' has been added to the metadata of the PipelineRun instances. This change ensures that when ArgoCD performs a comparison between the desired state in Git and the live state in the cluster, the diff will not include the PipelineRun resources, which are often ephemeral and can create noise in the diff output.

The additions have been made in both the unit test file (index.test.ts) and the corresponding utility function (index.ts) to ensure consistency and to maintain the integrity of the test suite.

Fixes #169 (if this is related to an existing issue)

Fixes https://github.com/epam/edp-tekton/issues/169

Type of change

How Has This Been Tested?
- Unit tests have been updated to reflect the new annotation, ensuring that the creation of PipelineRun instances includes the argocd.argoproj.io/compare-options annotation with the value 'IgnoreExtraneous'.
- Manual tests were conducted in a development environment to validate that the annotation behaves as expected within 

ArgoCD.

Checklist:
- [x]  I have performed a self-review of my own code
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.