### PR TITLE
feat: Align chart for ingress TLS configuration(#227)

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -42,7 +42,8 @@ A Helm chart for EDP Headlamp
 | imagePullSecrets | list | `[]` | An optional list of references to secrets in the same namespace to use for pulling any of the images used |
 | ingress.annotations | object | `{}` | Annotations for Ingress resource |
 | ingress.enabled | bool | `true` | Enable external endpoint access. Default Ingress/Route host pattern: portal-{{ .Release.Namespace }}.{{ .Values.global.dnsWildCard }} |
-| ingress.tls | list | `[]` | Ingress TLS configuration |
+| ingress.host | string | `""` | If hosts not defined the will create by pattern "portal-[namespace].[global DNS wildcard]" |
+| ingress.tls | list | `[]` | If hosts not defined the will create by pattern "portal-[namespace].[global DNS wildcard]" |
 | livenessProbe.failureThreshold | int | `5` |  |
 | livenessProbe.initialDelaySeconds | int | `5` |  |
 | livenessProbe.periodSeconds | int | `20` |  |

--- a/deploy-templates/templates/_helpers.tpl
+++ b/deploy-templates/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define portal URL
+*/}}
+{{- define "portal.url" -}}
+{{- printf "portal-%s.%s" .Release.Namespace .Values.global.dnsWildCard  }}
+{{- end }}

--- a/deploy-templates/templates/ingress.yaml
+++ b/deploy-templates/templates/ingress.yaml
@@ -20,14 +20,20 @@ spec:
   tls:
     {{- range .Values.ingress.tls }}
     - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
+        {{- if .hosts }}
+        {{- toYaml .hosts | nindent 8 }}
+        {{- else }}
+        - {{ include "portal.url" $ }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
-    - host: portal-{{ .Release.Namespace }}.{{ .Values.global.dnsWildCard }}
+    {{- if .Values.ingress.host }}
+    - host: {{ .Values.ingress.host }}
+    {{- else}}
+    - host: {{ include "portal.url" . }}
+    {{- end}}
       http:
         paths:
           - path: /

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -102,13 +102,15 @@ ingress:
     {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  # -- Hostname(s) for the Ingress resource
   # -- Ingress TLS configuration
+  # -- If hosts not defined the will create by pattern "portal-[namespace].[global DNS wildcard]"
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - portal-edp.example.com
-
+  # -- Defines the base URL for the portal.
+  # -- If hosts not defined the will create by pattern "portal-[namespace].[global DNS wildcard]"
+  host: ""
 # -- CPU/Memory resource requests/limits
 resources:
   {}


### PR DESCRIPTION
## Description
This pull request introduces enhancements to the ingress configuration and introduces a new template helper for generating dynamic portal URLs in the deploy-templates Helm chart. The changes streamline the setup process and provide more flexibility in configuring the access to services through ingress. Notably, the addition of a template helper for generating portal URLs based on the release namespace and global DNS wildcard simplifies the ingress setup for different environments. This update is crucial for deployments where custom ingress hostnames are needed or when leveraging dynamic DNS configurations.

## Fixes
Simplified ingress configuration with dynamic portal URL generation.
Enhanced flexibility in ingress setup, accommodating various deployment scenarios.
Improved documentation and clarity in values.yaml for portal URL configuration.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

The modifications were tested by deploying the Helm chart in different Kubernetes environments, verifying that the ingress correctly routes traffic to the service using both default and custom DNS configurations. The dynamic portal URL generation was tested by specifying different namespaces and verifying the resulting ingress hostnames matched expectations.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings