### PR TITLE
chore: Add annotation to control pod seesion timeout(#435)

### DIFF
--- a/deploy-templates/README.md
+++ b/deploy-templates/README.md
@@ -40,7 +40,7 @@ A Helm chart for KubeRocketCI Headlamp
 | image.repository | string | `"epamedp/edp-headlamp"` | KubeRocketCI headlamp Docker image name. The released image can be found on [Dockerhub](https://hub.docker.com/r/epamedp/edp-headlamp) |
 | image.tag | string | `nil` | KubeRocketCI headlamp Docker image tag. The released image can be found on [Dockerhub](https://hub.docker.com/r/epamedp/edp-headlamp/tags) |
 | imagePullSecrets | list | `[]` | An optional list of references to secrets in the same namespace to use for pulling any of the images used |
-| ingress.annotations | object | `{}` | Annotations for Ingress resource |
+| ingress.annotations | object | `{"nginx.ingress.kubernetes.io/proxy-read-timeout":"1800"}` | Annotations for Ingress resource |
 | ingress.enabled | bool | `true` | Enable external endpoint access. Default Ingress/Route host pattern: portal-{{ .Release.Namespace }}.{{ .Values.global.dnsWildCard }} |
 | ingress.host | string | `""` | If hosts not defined the will create by pattern "portal-[namespace].[global DNS wildcard]" |
 | ingress.tls | list | `[]` | If hosts not defined the will create by pattern "portal-[namespace].[global DNS wildcard]" |

--- a/deploy-templates/values.yaml
+++ b/deploy-templates/values.yaml
@@ -99,7 +99,7 @@ ingress:
   enabled: true
   # -- Annotations for Ingress resource
   annotations:
-    {}
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '1800'
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   # -- Ingress TLS configuration


### PR DESCRIPTION
This change adds a comment in the deploy-templates/values.yaml file to describe the purpose of the nginx.ingress.kubernetes.io/proxy-read-timeout annotation. It explains that this timeout defines how long the NGINX ingress controller will wait for a response from upstream services, such as a terminal pod session or long-running processes.

Fixes # (no specific issue).

Type of change
- [x]  New feature (non-breaking change which adds functionality)

How Has This Been Tested?
The change is a comment update, so no additional testing is required. It does not affect the logic or behavior of the application.

Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Pull Request contains one commit. I squash my commits.

Additional context
The update is a minor documentation improvement in the ingress section of the Helm chart's values.yaml file. This will help future developers understand the purpose of the proxy-read-timeout configuration for NGINX ingress.

