### PR TITLE
fix: Integration create popup actions 

### DIFF
--- a/src/widgets/ManageArgoCD/__snapshots__/index.create.test.tsx.snap
+++ b/src/widgets/ManageArgoCD/__snapshots__/index.create.test.tsx.snap
@@ -252,11 +252,11 @@ exports[`renders ManageArgoCD Create component 1`] = `
         class="MuiStack-root css-1a41st4-MuiStack-root"
       >
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit css-17jf5nl-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
-          <span />
+          cancel
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />

--- a/src/widgets/ManageArgoCD/components/Actions/index.tsx
+++ b/src/widgets/ManageArgoCD/components/Actions/index.tsx
@@ -5,6 +5,7 @@ import { ConditionalWrapper } from '../../../../components/ConditionalWrapper';
 import { ICONS } from '../../../../icons/iconify-icons-mapping';
 import { SecretKubeObject } from '../../../../k8s/groups/default/Secret';
 import { useDialogContext } from '../../../../providers/Dialog/hooks';
+import { FORM_MODES } from '../../../../types/forms';
 import { EDPKubeObjectInterface } from '../../../../types/k8s';
 import { DeleteKubeObjectDialog } from '../../../dialogs/DeleteKubeObject';
 import { useFormsContext } from '../../hooks/useFormsContext';
@@ -20,7 +21,7 @@ export const Actions = () => {
     isAnyFormForbiddenToSubmit,
   } = useFormsContext();
 
-  const { secret, ownerReference, permissions } = useDataContext();
+  const { secret, ownerReference, permissions, handleClosePanel } = useDataContext();
 
   const { setDialog } = useDialogContext();
 
@@ -48,20 +49,28 @@ export const Actions = () => {
     });
   }, [canDelete, secret, setDialog]);
 
+  const mode = !!secret ? FORM_MODES.EDIT : FORM_MODES.CREATE;
+
   return (
     <Stack direction="row" alignItems="center" spacing={2} sx={{ justifyContent: 'space-between' }}>
-      <ConditionalWrapper
-        condition={!canDelete}
-        wrapper={(children) => (
-          <Tooltip title={deleteDisabledTooltip}>
-            <div>{children}</div>
-          </Tooltip>
-        )}
-      >
-        <IconButton onClick={handleDelete} disabled={!canDelete} size="large">
-          <Icon icon={ICONS.BUCKET} width="20" />
-        </IconButton>
-      </ConditionalWrapper>
+      {mode === FORM_MODES.EDIT ? (
+        <ConditionalWrapper
+          condition={!canDelete}
+          wrapper={(children) => (
+            <Tooltip title={deleteDisabledTooltip}>
+              <div>{children}</div>
+            </Tooltip>
+          )}
+        >
+          <IconButton onClick={handleDelete} disabled={!canDelete} size="large">
+            <Icon icon={ICONS.BUCKET} width="20" />
+          </IconButton>
+        </ConditionalWrapper>
+      ) : (
+        <Button onClick={handleClosePanel} size="small" color="inherit">
+          cancel
+        </Button>
+      )}
 
       <Button
         onClick={resetAll}

--- a/src/widgets/ManageChatAssistant/__snapshots__/index.create.test.tsx.snap
+++ b/src/widgets/ManageChatAssistant/__snapshots__/index.create.test.tsx.snap
@@ -273,11 +273,11 @@ exports[`renders ManageChatAssistant Create component 1`] = `
         class="MuiStack-root css-1a41st4-MuiStack-root"
       >
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit css-17jf5nl-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
-          <span />
+          cancel
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />

--- a/src/widgets/ManageChatAssistant/components/Actions/index.tsx
+++ b/src/widgets/ManageChatAssistant/components/Actions/index.tsx
@@ -5,6 +5,7 @@ import { ConditionalWrapper } from '../../../../components/ConditionalWrapper';
 import { ICONS } from '../../../../icons/iconify-icons-mapping';
 import { SecretKubeObject } from '../../../../k8s/groups/default/Secret';
 import { useDialogContext } from '../../../../providers/Dialog/hooks';
+import { FORM_MODES } from '../../../../types/forms';
 import { EDPKubeObjectInterface } from '../../../../types/k8s';
 import { DeleteKubeObjectDialog } from '../../../dialogs/DeleteKubeObject';
 import { useFormsContext } from '../../hooks/useFormsContext';
@@ -20,7 +21,7 @@ export const Actions = () => {
     isAnyFormForbiddenToSubmit,
   } = useFormsContext();
 
-  const { secret, ownerReference, permissions } = useDataContext();
+  const { secret, ownerReference, permissions, handleClosePanel } = useDataContext();
 
   const { setDialog } = useDialogContext();
 
@@ -48,20 +49,28 @@ export const Actions = () => {
     });
   }, [canDelete, secret, setDialog]);
 
+  const mode = !!secret ? FORM_MODES.EDIT : FORM_MODES.CREATE;
+
   return (
     <Stack direction="row" alignItems="center" spacing={2} sx={{ justifyContent: 'space-between' }}>
-      <ConditionalWrapper
-        condition={!canDelete}
-        wrapper={(children) => (
-          <Tooltip title={deleteDisabledTooltip}>
-            <div>{children}</div>
-          </Tooltip>
-        )}
-      >
-        <IconButton onClick={handleDelete} disabled={!canDelete} size="large">
-          <Icon icon={ICONS.BUCKET} width="20" />
-        </IconButton>
-      </ConditionalWrapper>
+      {mode === FORM_MODES.EDIT ? (
+        <ConditionalWrapper
+          condition={!canDelete}
+          wrapper={(children) => (
+            <Tooltip title={deleteDisabledTooltip}>
+              <div>{children}</div>
+            </Tooltip>
+          )}
+        >
+          <IconButton onClick={handleDelete} disabled={!canDelete} size="large">
+            <Icon icon={ICONS.BUCKET} width="20" />
+          </IconButton>
+        </ConditionalWrapper>
+      ) : (
+        <Button onClick={handleClosePanel} size="small" color="inherit">
+          cancel
+        </Button>
+      )}
 
       <Button
         onClick={resetAll}

--- a/src/widgets/ManageDefectDojo/__snapshots__/index.create.test.tsx.snap
+++ b/src/widgets/ManageDefectDojo/__snapshots__/index.create.test.tsx.snap
@@ -252,11 +252,11 @@ exports[`renders ManageDefectDojo Create component 1`] = `
         class="MuiStack-root css-1a41st4-MuiStack-root"
       >
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit css-17jf5nl-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
-          <span />
+          cancel
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />

--- a/src/widgets/ManageDefectDojo/components/Actions/index.tsx
+++ b/src/widgets/ManageDefectDojo/components/Actions/index.tsx
@@ -5,6 +5,7 @@ import { ConditionalWrapper } from '../../../../components/ConditionalWrapper';
 import { ICONS } from '../../../../icons/iconify-icons-mapping';
 import { SecretKubeObject } from '../../../../k8s/groups/default/Secret';
 import { useDialogContext } from '../../../../providers/Dialog/hooks';
+import { FORM_MODES } from '../../../../types/forms';
 import { EDPKubeObjectInterface } from '../../../../types/k8s';
 import { DeleteKubeObjectDialog } from '../../../dialogs/DeleteKubeObject';
 import { useFormsContext } from '../../hooks/useFormsContext';
@@ -20,7 +21,7 @@ export const Actions = () => {
     isAnyFormForbiddenToSubmit,
   } = useFormsContext();
 
-  const { secret, ownerReference, permissions } = useDataContext();
+  const { secret, ownerReference, permissions, handleClosePanel } = useDataContext();
 
   const { setDialog } = useDialogContext();
 
@@ -48,20 +49,28 @@ export const Actions = () => {
     });
   }, [canDelete, secret, setDialog]);
 
+  const mode = !!secret ? FORM_MODES.EDIT : FORM_MODES.CREATE;
+
   return (
     <Stack direction="row" alignItems="center" spacing={2} sx={{ justifyContent: 'space-between' }}>
-      <ConditionalWrapper
-        condition={!canDelete}
-        wrapper={(children) => (
-          <Tooltip title={deleteDisabledTooltip}>
-            <div>{children}</div>
-          </Tooltip>
-        )}
-      >
-        <IconButton onClick={handleDelete} disabled={!canDelete} size="large">
-          <Icon icon={ICONS.BUCKET} width="20" />
-        </IconButton>
-      </ConditionalWrapper>
+      {mode === FORM_MODES.EDIT ? (
+        <ConditionalWrapper
+          condition={!canDelete}
+          wrapper={(children) => (
+            <Tooltip title={deleteDisabledTooltip}>
+              <div>{children}</div>
+            </Tooltip>
+          )}
+        >
+          <IconButton onClick={handleDelete} disabled={!canDelete} size="large">
+            <Icon icon={ICONS.BUCKET} width="20" />
+          </IconButton>
+        </ConditionalWrapper>
+      ) : (
+        <Button onClick={handleClosePanel} size="small" color="inherit">
+          cancel
+        </Button>
+      )}
 
       <Button
         onClick={resetAll}

--- a/src/widgets/ManageDependencyTrack/__snapshots__/index.create.test.tsx.snap
+++ b/src/widgets/ManageDependencyTrack/__snapshots__/index.create.test.tsx.snap
@@ -252,11 +252,11 @@ exports[`renders ManageDependencyTrack Create component 1`] = `
         class="MuiStack-root css-1a41st4-MuiStack-root"
       >
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit css-17jf5nl-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
-          <span />
+          cancel
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />

--- a/src/widgets/ManageDependencyTrack/components/Actions/index.tsx
+++ b/src/widgets/ManageDependencyTrack/components/Actions/index.tsx
@@ -5,6 +5,7 @@ import { ConditionalWrapper } from '../../../../components/ConditionalWrapper';
 import { ICONS } from '../../../../icons/iconify-icons-mapping';
 import { SecretKubeObject } from '../../../../k8s/groups/default/Secret';
 import { useDialogContext } from '../../../../providers/Dialog/hooks';
+import { FORM_MODES } from '../../../../types/forms';
 import { EDPKubeObjectInterface } from '../../../../types/k8s';
 import { DeleteKubeObjectDialog } from '../../../dialogs/DeleteKubeObject';
 import { useFormsContext } from '../../hooks/useFormsContext';
@@ -20,7 +21,7 @@ export const Actions = () => {
     isAnyFormForbiddenToSubmit,
   } = useFormsContext();
 
-  const { secret, ownerReference, permissions } = useDataContext();
+  const { secret, ownerReference, permissions, handleClosePanel } = useDataContext();
 
   const { setDialog } = useDialogContext();
 
@@ -48,20 +49,28 @@ export const Actions = () => {
     });
   }, [canDelete, secret, setDialog]);
 
+  const mode = !!secret ? FORM_MODES.EDIT : FORM_MODES.CREATE;
+
   return (
     <Stack direction="row" alignItems="center" spacing={2} sx={{ justifyContent: 'space-between' }}>
-      <ConditionalWrapper
-        condition={!canDelete}
-        wrapper={(children) => (
-          <Tooltip title={deleteDisabledTooltip}>
-            <div>{children}</div>
-          </Tooltip>
-        )}
-      >
-        <IconButton onClick={handleDelete} disabled={!canDelete} size="large">
-          <Icon icon={ICONS.BUCKET} width="20" />
-        </IconButton>
-      </ConditionalWrapper>
+      {mode === FORM_MODES.EDIT ? (
+        <ConditionalWrapper
+          condition={!canDelete}
+          wrapper={(children) => (
+            <Tooltip title={deleteDisabledTooltip}>
+              <div>{children}</div>
+            </Tooltip>
+          )}
+        >
+          <IconButton onClick={handleDelete} disabled={!canDelete} size="large">
+            <Icon icon={ICONS.BUCKET} width="20" />
+          </IconButton>
+        </ConditionalWrapper>
+      ) : (
+        <Button onClick={handleClosePanel} size="small" color="inherit">
+          cancel
+        </Button>
+      )}
 
       <Button
         onClick={resetAll}

--- a/src/widgets/ManageGitServer/__snapshots__/index.create.test.tsx.snap
+++ b/src/widgets/ManageGitServer/__snapshots__/index.create.test.tsx.snap
@@ -2433,11 +2433,11 @@ exports[`testing ManageGitServer Create renders ManageGitServer component withou
         class="MuiStack-root css-1a41st4-MuiStack-root"
       >
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit css-17jf5nl-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
-          <span />
+          cancel
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />
@@ -4897,11 +4897,11 @@ exports[`testing ManageGitServer Create renders ManageGitServer component withou
         class="MuiStack-root css-1a41st4-MuiStack-root"
       >
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit css-17jf5nl-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
-          <span />
+          cancel
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />
@@ -7361,11 +7361,11 @@ exports[`testing ManageGitServer Create renders ManageGitServer component withou
         class="MuiStack-root css-1a41st4-MuiStack-root"
       >
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit css-17jf5nl-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
-          <span />
+          cancel
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />
@@ -9825,11 +9825,11 @@ exports[`testing ManageGitServer Create renders ManageGitServer component withou
         class="MuiStack-root css-1a41st4-MuiStack-root"
       >
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit css-17jf5nl-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
-          <span />
+          cancel
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />
@@ -12289,11 +12289,11 @@ exports[`testing ManageGitServer Create renders ManageGitServer component withou
         class="MuiStack-root css-1a41st4-MuiStack-root"
       >
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit css-17jf5nl-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
-          <span />
+          cancel
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />

--- a/src/widgets/ManageGitServer/components/Actions/index.tsx
+++ b/src/widgets/ManageGitServer/components/Actions/index.tsx
@@ -3,6 +3,7 @@ import { Button, IconButton, Stack, Tooltip } from '@mui/material';
 import React from 'react';
 import { ConditionalWrapper } from '../../../../components/ConditionalWrapper';
 import { ICONS } from '../../../../icons/iconify-icons-mapping';
+import { FORM_MODES } from '../../../../types/forms';
 import { useFormsContext } from '../../hooks/useFormsContext';
 import { useDataContext } from '../../providers/Data/hooks';
 import { DeletionDialog } from '../DeletionDialog';
@@ -17,11 +18,14 @@ export const Actions = () => {
     isAnyFormForbiddenToSubmit,
   } = useFormsContext();
 
-  const { codebasesByGitServerQuery, permissions, gitServer, gitServerSecret } = useDataContext();
+  const { codebasesByGitServerQuery, permissions, gitServer, gitServerSecret, handleClosePanel } =
+    useDataContext();
   const submitDisabledTooltip = isAnyFormForbiddenToSubmit
     ? Object.values(forms).find(({ allowedToSubmit: { isAllowed } }) => !isAllowed)?.allowedToSubmit
         .reason
     : '';
+
+  const mode = !!gitServer ? FORM_MODES.EDIT : FORM_MODES.CREATE;
 
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
 
@@ -69,18 +73,24 @@ export const Actions = () => {
         alignItems="center"
         sx={{ justifyContent: 'space-between' }}
       >
-        <ConditionalWrapper
-          condition={deletedDisabledState.status}
-          wrapper={(children) => (
-            <Tooltip title={deletedDisabledState.reason}>
-              <div>{children}</div>
-            </Tooltip>
-          )}
-        >
-          <IconButton onClick={handleDelete} disabled={deletedDisabledState.status} size="large">
-            <Icon icon={ICONS.BUCKET} width="20" />
-          </IconButton>
-        </ConditionalWrapper>
+        {mode === FORM_MODES.EDIT ? (
+          <ConditionalWrapper
+            condition={deletedDisabledState.status}
+            wrapper={(children) => (
+              <Tooltip title={deletedDisabledState.reason}>
+                <div>{children}</div>
+              </Tooltip>
+            )}
+          >
+            <IconButton onClick={handleDelete} disabled={deletedDisabledState.status} size="large">
+              <Icon icon={ICONS.BUCKET} width="20" />
+            </IconButton>
+          </ConditionalWrapper>
+        ) : (
+          <Button onClick={handleClosePanel} size="small" color="inherit">
+            cancel
+          </Button>
+        )}
 
         <Button
           onClick={resetAll}

--- a/src/widgets/ManageGitServer/index.tsx
+++ b/src/widgets/ManageGitServer/index.tsx
@@ -56,6 +56,7 @@ export const ManageGitServer = ({
         gitServer={gitServer}
         gitServerSecret={gitServerSecret}
         permissions={permissions}
+        handleClosePanel={handleClosePanel}
       >
         <MultiFormContextProvider<FormNames>
           forms={{

--- a/src/widgets/ManageGitServer/providers/Data/types.ts
+++ b/src/widgets/ManageGitServer/providers/Data/types.ts
@@ -13,10 +13,12 @@ export interface DataContextProviderValue {
     KubeObjectListInterface<CodebaseKubeObjectInterface>,
     Error
   >;
+  handleClosePanel: (() => void) | undefined;
 }
 
 export interface DataContextProviderProps {
   gitServer: GitServerKubeObjectInterface | undefined;
   gitServerSecret: SecretKubeObjectInterface | undefined;
   permissions: WidgetPermissions;
+  handleClosePanel: (() => void) | undefined;
 }

--- a/src/widgets/ManageJiraServer/__snapshots__/index.create.test.tsx.snap
+++ b/src/widgets/ManageJiraServer/__snapshots__/index.create.test.tsx.snap
@@ -200,7 +200,18 @@ exports[`renders ManageJiraServer Create component 1`] = `
       >
         <div
           class="MuiBox-root css-1po99kh"
-        />
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit css-17jf5nl-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            cancel
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
         <div
           class="MuiStack-root css-pl8gqh-MuiStack-root"
         >

--- a/src/widgets/ManageJiraServer/components/Actions/index.tsx
+++ b/src/widgets/ManageJiraServer/components/Actions/index.tsx
@@ -4,16 +4,13 @@ import React from 'react';
 import { ConditionalWrapper } from '../../../../components/ConditionalWrapper';
 import { ICONS } from '../../../../icons/iconify-icons-mapping';
 import { useDialogContext } from '../../../../providers/Dialog/hooks';
+import { FORM_MODES } from '../../../../types/forms';
 import { ConfirmResourcesUpdatesDialog } from '../../../dialogs/ConfirmResourcesUpdates';
 import { useFormsContext } from '../../hooks/useFormsContext';
 import { useResetIntegration } from '../../hooks/useResetIntegration';
 import { useDataContext } from '../../providers/Data/hooks';
 
-export const Actions = ({
-  handleCloseCreateDialog,
-}: {
-  handleCloseCreateDialog: (() => void) | undefined;
-}) => {
+export const Actions = () => {
   const {
     forms,
     resetAll,
@@ -23,7 +20,7 @@ export const Actions = ({
     isAnyFormForbiddenToSubmit,
   } = useFormsContext();
 
-  const { jiraServer, secret, ownerReference, permissions } = useDataContext();
+  const { jiraServer, secret, ownerReference, permissions, handleClosePanel } = useDataContext();
 
   const { resetJiraIntegration, isLoading: isResetting } = useResetIntegration();
   const { setDialog } = useDialogContext();
@@ -39,10 +36,12 @@ export const Actions = ({
     ? 'Jira Secret has external owners. Please, delete it by your own.'
     : permissions?.delete?.Secret.reason;
 
+  const mode = !!jiraServer ? FORM_MODES.EDIT : FORM_MODES.CREATE;
+
   return (
     <Stack direction="row" spacing={2} sx={{ justifyContent: 'space-between' }}>
       <Box sx={{ mr: 'auto' }}>
-        {(jiraServer || secret) && (
+        {mode === FORM_MODES.EDIT ? (
           <ConditionalWrapper
             condition={!canReset}
             wrapper={(children) => {
@@ -69,6 +68,10 @@ export const Actions = ({
               Reset integration
             </Button>
           </ConditionalWrapper>
+        ) : (
+          <Button onClick={handleClosePanel} size="small" color="inherit">
+            cancel
+          </Button>
         )}
       </Box>
       <Stack direction="row" spacing={2}>
@@ -86,7 +89,7 @@ export const Actions = ({
           <Button
             onClick={() => {
               submitAll(true);
-              handleCloseCreateDialog && handleCloseCreateDialog();
+              handleClosePanel && handleClosePanel();
             }}
             size={'small'}
             component={'button'}

--- a/src/widgets/ManageJiraServer/index.tsx
+++ b/src/widgets/ManageJiraServer/index.tsx
@@ -57,7 +57,7 @@ export const ManageJiraServer = ({
               <SecretForm />
             </Grid>
             <Grid item xs={12}>
-              <Actions handleCloseCreateDialog={handleClosePanel} />
+              <Actions />
             </Grid>
           </Grid>
         </MultiFormContextProvider>

--- a/src/widgets/ManageNexus/__snapshots__/index.create.test.tsx.snap
+++ b/src/widgets/ManageNexus/__snapshots__/index.create.test.tsx.snap
@@ -302,11 +302,11 @@ exports[`renders ManageNexus Create component 1`] = `
         class="MuiStack-root css-1a41st4-MuiStack-root"
       >
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit css-17jf5nl-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
-          <span />
+          cancel
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />

--- a/src/widgets/ManageNexus/components/Actions/index.tsx
+++ b/src/widgets/ManageNexus/components/Actions/index.tsx
@@ -5,6 +5,7 @@ import { ConditionalWrapper } from '../../../../components/ConditionalWrapper';
 import { ICONS } from '../../../../icons/iconify-icons-mapping';
 import { SecretKubeObject } from '../../../../k8s/groups/default/Secret';
 import { useDialogContext } from '../../../../providers/Dialog/hooks';
+import { FORM_MODES } from '../../../../types/forms';
 import { EDPKubeObjectInterface } from '../../../../types/k8s';
 import { DeleteKubeObjectDialog } from '../../../dialogs/DeleteKubeObject';
 import { useFormsContext } from '../../hooks/useFormsContext';
@@ -20,7 +21,7 @@ export const Actions = () => {
     isAnyFormForbiddenToSubmit,
   } = useFormsContext();
 
-  const { secret, ownerReference, permissions } = useDataContext();
+  const { secret, ownerReference, permissions, handleClosePanel } = useDataContext();
 
   const { setDialog } = useDialogContext();
 
@@ -48,20 +49,28 @@ export const Actions = () => {
         .reason
     : '';
 
+  const mode = !!secret ? FORM_MODES.EDIT : FORM_MODES.CREATE;
+
   return (
     <Stack direction="row" alignItems="center" spacing={2} sx={{ justifyContent: 'space-between' }}>
-      <ConditionalWrapper
-        condition={!canDelete}
-        wrapper={(children) => (
-          <Tooltip title={deleteDisabledTooltip}>
-            <div>{children}</div>
-          </Tooltip>
-        )}
-      >
-        <IconButton onClick={handleDelete} disabled={!canDelete} size="large">
-          <Icon icon={ICONS.BUCKET} width="20" />
-        </IconButton>
-      </ConditionalWrapper>
+      {mode === FORM_MODES.EDIT ? (
+        <ConditionalWrapper
+          condition={!canDelete}
+          wrapper={(children) => (
+            <Tooltip title={deleteDisabledTooltip}>
+              <div>{children}</div>
+            </Tooltip>
+          )}
+        >
+          <IconButton onClick={handleDelete} disabled={!canDelete} size="large">
+            <Icon icon={ICONS.BUCKET} width="20" />
+          </IconButton>
+        </ConditionalWrapper>
+      ) : (
+        <Button onClick={handleClosePanel} size="small" color="inherit">
+          cancel
+        </Button>
+      )}
 
       <Button
         onClick={resetAll}

--- a/src/widgets/ManageRegistry/__snapshots__/index.create.test.tsx.snap
+++ b/src/widgets/ManageRegistry/__snapshots__/index.create.test.tsx.snap
@@ -1717,18 +1717,14 @@ exports[`testing ManageRegistry Create renders ManageRegistry component without 
           class="MuiBox-root css-1po99kh"
         >
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-vw8gqz-MuiButtonBase-root-MuiButton-root"
-            disabled=""
-            style="pointer-events: auto;"
-            tabindex="-1"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit css-17jf5nl-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
             type="button"
           >
+            cancel
             <span
-              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
-            >
-              <span />
-            </span>
-            Reset registry
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
           </button>
         </div>
         <div

--- a/src/widgets/ManageRegistry/components/Actions/index.tsx
+++ b/src/widgets/ManageRegistry/components/Actions/index.tsx
@@ -5,6 +5,7 @@ import { ConditionalWrapper } from '../../../../components/ConditionalWrapper';
 import { ICONS } from '../../../../icons/iconify-icons-mapping';
 import { CONTAINER_REGISTRY_TYPE } from '../../../../k8s/groups/default/ConfigMap/constants';
 import { useDialogContext } from '../../../../providers/Dialog/hooks';
+import { FORM_MODES } from '../../../../types/forms';
 import { ConfirmResourcesUpdatesDialog } from '../../../dialogs/ConfirmResourcesUpdates';
 import { useRegistryFormsContext } from '../../hooks/useRegistryFormsContext';
 import { useResetRegistry } from '../../hooks/useResetRegistry';
@@ -68,35 +69,43 @@ export const Actions = ({
     ? 'Some of the secrets has external owners. Please, delete it by your own.'
     : permissions?.delete?.Secret.reason;
 
+  const mode = !!registryType ? FORM_MODES.EDIT : FORM_MODES.CREATE;
+
   return (
     <Stack direction="row" spacing={2} sx={{ justifyContent: 'space-between' }}>
       <Box sx={{ mr: 'auto' }}>
-        <ConditionalWrapper
-          condition={!canReset}
-          wrapper={(children) => {
-            return <Tooltip title={deleteDisabledTooltip}>{children}</Tooltip>;
-          }}
-        >
-          <Button
-            variant="contained"
-            size="small"
-            color="primary"
-            style={{ pointerEvents: 'auto' }}
-            onClick={() => {
-              setDialog(ConfirmResourcesUpdatesDialog, {
-                deleteCallback: () => {
-                  resetRegistry();
-                },
-                text: 'Are you sure you want to reset the registry?',
-                resourcesArray: [],
-              });
+        {mode === FORM_MODES.EDIT ? (
+          <ConditionalWrapper
+            condition={!canReset}
+            wrapper={(children) => {
+              return <Tooltip title={deleteDisabledTooltip}>{children}</Tooltip>;
             }}
-            startIcon={<Icon icon={ICONS.WARNING} />}
-            disabled={!registryType || someOfTheSecretsHasExternalOwner}
           >
-            Reset registry
+            <Button
+              variant="contained"
+              size="small"
+              color="primary"
+              style={{ pointerEvents: 'auto' }}
+              onClick={() => {
+                setDialog(ConfirmResourcesUpdatesDialog, {
+                  deleteCallback: () => {
+                    resetRegistry();
+                  },
+                  text: 'Are you sure you want to reset the registry?',
+                  resourcesArray: [],
+                });
+              }}
+              startIcon={<Icon icon={ICONS.WARNING} />}
+              disabled={!registryType || someOfTheSecretsHasExternalOwner}
+            >
+              Reset registry
+            </Button>
+          </ConditionalWrapper>
+        ) : (
+          <Button onClick={handleCloseCreateDialog} size="small" color="inherit">
+            cancel
           </Button>
-        </ConditionalWrapper>
+        )}
       </Box>
       <Stack direction="row" spacing={2}>
         <Button onClick={resetAll} size="small" component={'button'} disabled={!isAnyFormDirty}>

--- a/src/widgets/ManageSonar/__snapshots__/index.create.test.tsx.snap
+++ b/src/widgets/ManageSonar/__snapshots__/index.create.test.tsx.snap
@@ -252,11 +252,11 @@ exports[`renders ManageSonar Create component 1`] = `
         class="MuiStack-root css-1a41st4-MuiStack-root"
       >
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorInherit css-17jf5nl-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
-          <span />
+          cancel
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />

--- a/src/widgets/ManageSonar/components/Actions/index.tsx
+++ b/src/widgets/ManageSonar/components/Actions/index.tsx
@@ -5,6 +5,7 @@ import { ConditionalWrapper } from '../../../../components/ConditionalWrapper';
 import { ICONS } from '../../../../icons/iconify-icons-mapping';
 import { SecretKubeObject } from '../../../../k8s/groups/default/Secret';
 import { useDialogContext } from '../../../../providers/Dialog/hooks';
+import { FORM_MODES } from '../../../../types/forms';
 import { EDPKubeObjectInterface } from '../../../../types/k8s';
 import { DeleteKubeObjectDialog } from '../../../dialogs/DeleteKubeObject';
 import { useFormsContext } from '../../hooks/useFormsContext';
@@ -20,7 +21,7 @@ export const Actions = () => {
     isAnyFormForbiddenToSubmit,
   } = useFormsContext();
 
-  const { secret, ownerReference, permissions } = useDataContext();
+  const { secret, ownerReference, permissions, handleClosePanel } = useDataContext();
 
   const { setDialog } = useDialogContext();
 
@@ -48,20 +49,28 @@ export const Actions = () => {
     });
   }, [canDelete, secret, setDialog]);
 
+  const mode = !!secret ? FORM_MODES.EDIT : FORM_MODES.CREATE;
+
   return (
     <Stack direction="row" alignItems="center" spacing={2} sx={{ justifyContent: 'space-between' }}>
-      <ConditionalWrapper
-        condition={!canDelete}
-        wrapper={(children) => (
-          <Tooltip title={deleteDisabledTooltip}>
-            <div>{children}</div>
-          </Tooltip>
-        )}
-      >
-        <IconButton onClick={handleDelete} disabled={!canDelete} size="large">
-          <Icon icon={ICONS.BUCKET} width="20" />
-        </IconButton>
-      </ConditionalWrapper>
+      {mode === FORM_MODES.EDIT ? (
+        <ConditionalWrapper
+          condition={!canDelete}
+          wrapper={(children) => (
+            <Tooltip title={deleteDisabledTooltip}>
+              <div>{children}</div>
+            </Tooltip>
+          )}
+        >
+          <IconButton onClick={handleDelete} disabled={!canDelete} size="large">
+            <Icon icon={ICONS.BUCKET} width="20" />
+          </IconButton>
+        </ConditionalWrapper>
+      ) : (
+        <Button onClick={handleClosePanel} size="small" color="inherit">
+          cancel
+        </Button>
+      )}
 
       <Button
         onClick={resetAll}


### PR DESCRIPTION
# Pull Request Template

## Description
Currently, when users open create integration dialog they can see delete button which should'be shown even if there is secret attached to such integration, but only when main integration resource is available

Fixes #714 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):

## Additional context
Add any other context or screenshots about the feature request here.