### PR TITLE
chore: Bump GitHub Actions runner image to 22.04(#735)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
 
   check-commit-message:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COMMIT_MESSAGE_PATTERN: '^(feat|fix|docs|style|refactor|test|chore){1}(!)?:\s[A-Z][a-z]([\/\.\w\-\s]+)\(\#\d+\)$'
       MAX_LINE_LENGTH: '80'
@@ -48,7 +48,7 @@ jobs:
 
   helm-docs:
     needs: [check-commit-message]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -62,7 +62,7 @@ jobs:
 
   helm-lint:
     needs: [helm-docs]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
      CHART_DIR: "deploy-templates"
      CT_CONFIGS_DIR: "."
@@ -99,7 +99,7 @@ jobs:
 
   build-lint-kaniko:
     needs: [helm-lint]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [16.x]
@@ -154,7 +154,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
   docker-lint:
     needs: [build-lint-kaniko]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates all GitHub Actions workflows to use the ubuntu-22.04 runner image instead of the deprecated ubuntu-20.04.
GitHub has scheduled the removal of ubuntu-20.04 from their hosted runners on April 15, 2025, as per [this issue](https://github.com/actions/runner-images/issues/11101).
Upgrading now ensures continued CI stability and avoids disruption when the deprecation is enforced.

Fixes #735 

Type of change
 - [x] Enhancement (non-breaking change which improves an existing feature or documentation)

How Has This Been Tested?
All affected workflows were executed on ubuntu-22.04 to ensure successful build and test completion.

Verified that no tools or dependencies broke due to OS version change.

Logs were reviewed for compatibility warnings or errors.

Checklist:
 - [x] I have performed a self-review of my code

 - [ ] I have commented on my code, particularly in hard-to-understand areas (N/A for this change)

 - [ ] I have made corresponding changes to the documentation (CI config references)

 - [x] My changes generate no new warnings

 - [ ] I have added tests that prove my fix is effective or that my feature works (Existing tests re-run)

 - [x] New and existing unit tests pass locally with my changes

 Pull Request contains one commit. I squash my commits.