### PR TITLE
feat: Add GitLab CI support to Portal UI (#824)

### DIFF
--- a/src/configs/icon-mappings/index.ts
+++ b/src/configs/icon-mappings/index.ts
@@ -33,6 +33,7 @@ export const CODEBASE_ICON_PATTERNS = [
   { pattern: /^opa$/i, icon: RESOURCE_ICON_NAMES.OPA },
   { pattern: /^docker$/i, icon: RESOURCE_ICON_NAMES.DOCKER },
   { pattern: /^pipeline$|^tekton$/i, icon: RESOURCE_ICON_NAMES.TEKTON },
+  { pattern: /^gitlab$/i, icon: RESOURCE_ICON_NAMES.GITLAB },
   { pattern: /^beego$/i, icon: RESOURCE_ICON_NAMES.BEEGO },
   { pattern: /^flask$/i, icon: RESOURCE_ICON_NAMES.FLASK },
   { pattern: /^charts$/i, icon: RESOURCE_ICON_NAMES.HELM },
@@ -132,6 +133,7 @@ export const BUILD_TOOL_ICON_MAPPING = {
 
 export const CI_TOOL_ICON_MAPPING = {
   [CI_TOOL.TEKTON]: RESOURCE_ICON_NAMES.TEKTON,
+  [CI_TOOL.GITLAB]: RESOURCE_ICON_NAMES.GITLAB,
 } as const;
 
 export const GIT_PROVIDER_ICON_MAPPING = {

--- a/src/constants/ciTools.ts
+++ b/src/constants/ciTools.ts
@@ -1,3 +1,4 @@
 export const CI_TOOL = {
   TEKTON: 'tekton',
+  GITLAB: 'gitlab',
 } as const;

--- a/src/widgets/ManageGitOps/__snapshots__/index.create.test.tsx.snap
+++ b/src/widgets/ManageGitOps/__snapshots__/index.create.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`renders ManageGitOps Create component 1`] = `
           class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-mhc70k-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-1osj8n2-MuiGrid-root"
           >
             <div
               class="MuiStack-root css-jfdv4h-MuiStack-root"
@@ -223,6 +223,74 @@ exports[`renders ManageGitOps Create component 1`] = `
             </div>
           </div>
           <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-1osj8n2-MuiGrid-root"
+          >
+            <div
+              class="MuiStack-root css-jfdv4h-MuiStack-root"
+            >
+              <div
+                class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
+              >
+                <label
+                  class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-98a9yt-MuiFormLabel-root-MuiInputLabel-root"
+                  data-shrink="true"
+                >
+                  CI Pipelines
+                </label>
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-fullWidth MuiInputBase-formControl  css-zc9d61-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+                >
+                  <div
+                    aria-controls="mui-3"
+                    aria-disabled="true"
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-labelledby="mui-component-select-ciTool"
+                    class="MuiSelect-select MuiSelect-outlined Mui-disabled MuiInputBase-input MuiOutlinedInput-input Mui-disabled css-17praur-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                    id="mui-component-select-ciTool"
+                    role="combobox"
+                  >
+                    Tekton
+                  </div>
+                  <input
+                    aria-hidden="true"
+                    aria-invalid="false"
+                    class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                    disabled=""
+                    name="ciTool"
+                    tabindex="-1"
+                    value="tekton"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined Mui-disabled css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+                    data-testid="ArrowDropDownIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 10l5 5 5-5z"
+                    />
+                  </svg>
+                  <fieldset
+                    aria-hidden="true"
+                    class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="css-ihdtdm"
+                    >
+                      <span
+                        class="notranslate"
+                      >
+                        ​
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-3 css-1equabv-MuiGrid-root"
           >
             <div
@@ -237,8 +305,8 @@ exports[`renders ManageGitOps Create component 1`] = `
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-98a9yt-MuiFormLabel-root-MuiInputLabel-root"
                     data-shrink="true"
-                    for="mui-4"
-                    id="mui-4-label"
+                    for="mui-5"
+                    id="mui-5-label"
                   >
                     Repository Name
                   </label>
@@ -257,7 +325,7 @@ exports[`renders ManageGitOps Create component 1`] = `
                     <input
                       aria-invalid="false"
                       class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-152mnda-MuiInputBase-input-MuiOutlinedInput-input"
-                      id="mui-4"
+                      id="mui-5"
                       name="name"
                       type="text"
                       value="krci-gitops"

--- a/src/widgets/ManageGitOps/components/Create/index.tsx
+++ b/src/widgets/ManageGitOps/components/Create/index.tsx
@@ -7,7 +7,7 @@ import { useGitServerListQuery } from '../../../../k8s/groups/EDP/GitServer/hook
 import { MainRadioGroup } from '../../../../providers/Form/components/MainRadioGroup';
 import { CODEBASE_FORM_NAMES } from '../../names';
 import { ManageGitOpsValues } from '../../types';
-import { GitRepoPath, GitServer, Name } from '../fields';
+import { CiTool, GitRepoPath, GitServer, Name } from '../fields';
 
 const codebaseCreationStrategies = [
   {
@@ -71,11 +71,14 @@ export const Create = () => {
 
       <Box sx={{ p: `${theme.typography.pxToRem(24)} ${theme.typography.pxToRem(8)}` }}>
         <Grid container spacing={2}>
-          <Grid item xs={4}>
+          <Grid item xs={6}>
             <GitServer />
           </Grid>
+          <Grid item xs={6}>
+            <CiTool />
+          </Grid>
           {gitServerProvider !== GIT_PROVIDER.GERRIT && !!isFetched && (
-            <Grid item xs={5}>
+            <Grid item xs={9}>
               <GitRepoPath />
             </Grid>
           )}

--- a/src/widgets/ManageGitOps/components/fields/CiTool/index.tsx
+++ b/src/widgets/ManageGitOps/components/fields/CiTool/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useFormContext as useReactHookFormContext } from 'react-hook-form';
+import { CI_TOOL } from '../../../../../constants/ciTools';
+import { useGitServerListQuery } from '../../../../../k8s/groups/EDP/GitServer/hooks/useGitServerListQuery';
+import { FormSelect } from '../../../../../providers/Form/components/FormSelect';
+import { useFormContext } from '../../../../../providers/Form/hooks';
+import { CODEBASE_FORM_NAMES } from '../../../names';
+import { ManageGitOpsDataContext, ManageGitOpsValues } from '../../../types';
+
+export const CiTool = () => {
+  const {
+    register,
+    control,
+    formState: { errors },
+    watch,
+  } = useReactHookFormContext<ManageGitOpsValues>();
+
+  const {
+    formData: { isReadOnly },
+  } = useFormContext<ManageGitOpsDataContext>();
+  const { data: gitServers } = useGitServerListQuery();
+
+  const gitServerFieldValue = watch(CODEBASE_FORM_NAMES.gitServer.name);
+  const selectedGitServer = gitServers?.items.find(
+    (gitServer) => gitServer.metadata.name === gitServerFieldValue
+  );
+
+  const isGitlabProvider = selectedGitServer?.spec.gitProvider === 'gitlab';
+
+  const ciToolOptions = [
+    { label: 'Tekton', value: CI_TOOL.TEKTON },
+    ...(isGitlabProvider ? [{ label: 'GitLab CI', value: CI_TOOL.GITLAB }] : []),
+  ];
+
+  return (
+    <FormSelect
+      {...register(CODEBASE_FORM_NAMES.ciTool.name)}
+      label="CI Pipelines"
+      control={control}
+      errors={errors}
+      options={ciToolOptions}
+      disabled={!isGitlabProvider || isReadOnly}
+    />
+  );
+};

--- a/src/widgets/ManageGitOps/components/fields/index.ts
+++ b/src/widgets/ManageGitOps/components/fields/index.ts
@@ -1,3 +1,4 @@
+export * from './CiTool';
 export * from './GitRepoPath';
 export * from './GitServer';
 export * from './Name';

--- a/src/widgets/dialogs/CreateCodebaseFromTemplate/components/Form/index.tsx
+++ b/src/widgets/dialogs/CreateCodebaseFromTemplate/components/Form/index.tsx
@@ -1,6 +1,6 @@
 import { Grid } from '@mui/material';
 import React from 'react';
-import { CodebaseVersioning, Description, GitServer, GitUrlPath, Name, Private } from '../fields';
+import { CiTool, CodebaseVersioning, Description, GitServer, GitUrlPath, Name, Private } from '../fields';
 import { useUpdateVersioningFields } from './hooks/useUpdateVersioningFields';
 
 export const Form = () => {
@@ -15,14 +15,13 @@ export const Form = () => {
         <Description />
       </Grid>
       <Grid item xs={12}>
-        <Grid container spacing={2} alignItems={'flex-start'}>
-          <Grid item xs={4}>
-            <GitServer />
-          </Grid>
-          <Grid item xs={8}>
-            <GitUrlPath />
-          </Grid>
-        </Grid>
+        <GitServer />
+      </Grid>
+      <Grid item xs={12}>
+        <GitUrlPath />
+      </Grid>
+      <Grid item xs={12}>
+        <CiTool />
       </Grid>
       <Grid item xs={12}>
         <Private />

--- a/src/widgets/dialogs/CreateCodebaseFromTemplate/components/fields/CiTool/index.tsx
+++ b/src/widgets/dialogs/CreateCodebaseFromTemplate/components/fields/CiTool/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { CI_TOOL } from '../../../../../../constants/ciTools';
+import { useGitServerListQuery } from '../../../../../../k8s/groups/EDP/GitServer/hooks/useGitServerListQuery';
+import { FormSelect } from '../../../../../../providers/Form/components/FormSelect';
+import { useTypedFormContext } from '../../../hooks/useFormContext';
+import { CODEBASE_FROM_TEMPLATE_FORM_NAMES } from '../../../names';
+
+export const CiTool = () => {
+  const {
+    register,
+    control,
+    formState: { errors },
+    watch,
+  } = useTypedFormContext();
+  const { data: gitServers } = useGitServerListQuery();
+
+  const gitServerFieldValue = watch(CODEBASE_FROM_TEMPLATE_FORM_NAMES.gitServer.name);
+  const selectedGitServer = gitServers?.items.find(
+    (gitServer) => gitServer.metadata.name === gitServerFieldValue
+  );
+
+  const isGitlabProvider = selectedGitServer?.spec.gitProvider === 'gitlab';
+
+  const ciToolOptions = [
+    { label: 'Tekton', value: CI_TOOL.TEKTON },
+    ...(isGitlabProvider ? [{ label: 'GitLab CI', value: CI_TOOL.GITLAB }] : []),
+  ];
+
+  return (
+    <FormSelect
+      {...register(CODEBASE_FROM_TEMPLATE_FORM_NAMES.ciTool.name)}
+      label="CI Pipelines"
+      control={control}
+      errors={errors}
+      options={ciToolOptions}
+      disabled={!isGitlabProvider}
+    />
+  );
+};

--- a/src/widgets/dialogs/CreateCodebaseFromTemplate/components/fields/index.ts
+++ b/src/widgets/dialogs/CreateCodebaseFromTemplate/components/fields/index.ts
@@ -1,3 +1,4 @@
+export * from './CiTool';
 export * from './CodebaseVersioning';
 export * from './Description';
 export * from './GitServer';

--- a/src/widgets/dialogs/ManageCodebase/components/Create/components/Inner/components/Form/components/Info/index.tsx
+++ b/src/widgets/dialogs/ManageCodebase/components/Create/components/Inner/components/Form/components/Info/index.tsx
@@ -10,6 +10,7 @@ import { useCurrentDialog } from '../../../../../../../../providers/CurrentDialo
 import { isCloneStrategy } from '../../../../../../../../utils';
 import {
   BuildTool,
+  CiTool,
   CodebaseAuth,
   Description,
   EmptyProject,
@@ -73,6 +74,10 @@ export const Info = () => {
               </>
             )}
           </Stack>
+        </Grid>
+
+        <Grid item xs={12}>
+          <CiTool />
         </Grid>
 
         {isCloneStrategy(strategyFieldValue) ? (

--- a/src/widgets/dialogs/ManageCodebase/components/fields/CiTool/index.tsx
+++ b/src/widgets/dialogs/ManageCodebase/components/fields/CiTool/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { CI_TOOL } from '../../../../../../constants/ciTools';
+import { useGitServerListQuery } from '../../../../../../k8s/groups/EDP/GitServer/hooks/useGitServerListQuery';
+import { FormSelect } from '../../../../../../providers/Form/components/FormSelect';
+import { useTypedFormContext } from '../../../hooks/useFormContext';
+import { CODEBASE_FORM_NAMES } from '../../../names';
+
+export const CiTool = () => {
+  const {
+    register,
+    control,
+    formState: { errors },
+    watch,
+  } = useTypedFormContext();
+  const { data: gitServers } = useGitServerListQuery();
+
+  const gitServerFieldValue = watch(CODEBASE_FORM_NAMES.gitServer.name);
+  const selectedGitServer = gitServers?.items.find(
+    (gitServer) => gitServer.metadata.name === gitServerFieldValue
+  );
+
+  const isGitlabProvider = selectedGitServer?.spec.gitProvider === 'gitlab';
+
+  const ciToolOptions = [
+    { label: 'Tekton', value: CI_TOOL.TEKTON },
+    ...(isGitlabProvider ? [{ label: 'GitLab CI', value: CI_TOOL.GITLAB }] : []),
+  ];
+
+  return (
+    <FormSelect
+      {...register(CODEBASE_FORM_NAMES.ciTool.name)}
+      label="CI Pipelines"
+      control={control}
+      errors={errors}
+      options={ciToolOptions}
+      disabled={!isGitlabProvider}
+    />
+  );
+};

--- a/src/widgets/dialogs/ManageCodebase/components/fields/index.ts
+++ b/src/widgets/dialogs/ManageCodebase/components/fields/index.ts
@@ -1,5 +1,6 @@
 export * from './AdvancedJiraMapping';
 export * from './BuildTool';
+export * from './CiTool';
 export * from './CodebaseAuth';
 export * from './CodebaseVersioning';
 export * from './CommitMessagePattern';


### PR DESCRIPTION
- Add GitLab CI as selectable option in CI tool dropdowns
- Create CiTool components for ManageCodebase, CreateCodebaseFromTemplate, and ManageGitOps dialogs
- Enable conditional GitLab CI option when Git Server provider is GitLab
- Add GitLab icon pattern for proper display in component overview
- Position CI Pipelines field after repository information in forms
- Maintain backward compatibility with existing Tekton default

Related issue #824

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking change which improves an existing feature or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?
Checked on local env

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pull Request contains one commit. I squash my commits.

## Screenshots (if appropriate):
