### PR TITLE
refactor(notifications): align GitLab notifications with Tekton pattern

### DIFF
--- a/src/components/Snackbar/index.tsx
+++ b/src/components/Snackbar/index.tsx
@@ -25,10 +25,14 @@ export const Snackbar = React.forwardRef<
       };
       text?: string;
     };
+    externalLink?: {
+      url: string;
+      text?: string;
+    };
     handleClose?: () => void;
   }
 >((props, ref) => {
-  const { text, variant, snackbarKey, pushLocation } = props;
+  const { text, variant, snackbarKey, pushLocation, externalLink } = props;
   const { closeSnackbar } = useSnackbar();
 
   const theme = React.useMemo(() => {
@@ -98,6 +102,20 @@ export const Snackbar = React.forwardRef<
               onClick={handleClose}
             >
               {pushLocation.text || 'Go to page'}
+            </Button>
+          )}
+          {externalLink && (
+            <Button
+              component="a"
+              size="small"
+              variant="outlined"
+              color="inherit"
+              href={externalLink.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handleClose}
+            >
+              {externalLink.text || 'View'}
             </Button>
           )}
           <IconButton size="small" onClick={handleClose}>

--- a/src/hooks/useCreateGitLabPipeline/index.tsx
+++ b/src/hooks/useCreateGitLabPipeline/index.tsx
@@ -2,6 +2,7 @@ import { Utils } from '@kinvolk/headlamp-plugin/lib';
 import { useSnackbar } from 'notistack';
 import React, { useCallback } from 'react';
 import { useMutation } from 'react-query';
+import { Snackbar } from '../../components/Snackbar';
 import { useEDPConfigMapQuery } from '../../k8s/groups/default/ConfigMap/hooks/useEDPConfigMap';
 import { ApiServiceBase, GitFusionApiService } from '../../services/api';
 import { getToken } from '../../utils/getToken';
@@ -59,17 +60,22 @@ export const useCreateGitLabPipeline = ({
       onSuccess: (response) => {
         enqueueSnackbar('GitLab pipeline triggered successfully!', {
           variant: 'success',
-          autoHideDuration: 5000,
-          action: response.web_url ? (
-            <a
-              href={response.web_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ color: 'white', textDecoration: 'underline' }}
-            >
-              View Pipeline
-            </a>
-          ) : undefined,
+          autoHideDuration: 8000,
+          content: (key, message) => (
+            <Snackbar
+              text={String(message)}
+              snackbarKey={key}
+              externalLink={
+                response.web_url
+                  ? {
+                      url: response.web_url,
+                      text: 'View Pipeline',
+                    }
+                  : undefined
+              }
+              variant={'success'}
+            />
+          ),
         });
         invokeOnSuccessCallback(response);
       },


### PR DESCRIPTION
Extend Snackbar component to support external links and refactor useCreateGitLabPipeline hook to use the shared notification component instead of inline notification code.

- Add externalLink prop to Snackbar for external URLs
- Remove custom notification implementation from GitLab hook
- Maintain consistent UX between Tekton and GitLab pipelines

Refs: #824

